### PR TITLE
Add react study control example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# study-control
+# Study Control
+
+This is a minimal example of a study control application built with React, Vite, Tailwind CSS and shadcn-inspired components.
+
+## Development
+
+1. Install dependencies
+
+```bash
+npm install
+```
+
+2. Run the development server
+
+```bash
+npm run dev
+```
+
+The application stores tasks in `localStorage` so your data persists between page reloads.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Study Control</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "study-control",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+import { Button } from './components/ui/Button';
+
+interface StudyTask {
+  id: number;
+  title: string;
+  completed: boolean;
+}
+
+function App() {
+  const [tasks, setTasks] = useState<StudyTask[]>([]);
+  const [input, setInput] = useState('');
+
+  // Load tasks from localStorage
+  useEffect(() => {
+    const stored = localStorage.getItem('study-tasks');
+    if (stored) {
+      setTasks(JSON.parse(stored));
+    }
+  }, []);
+
+  // Save tasks when they change
+  useEffect(() => {
+    localStorage.setItem('study-tasks', JSON.stringify(tasks));
+  }, [tasks]);
+
+  const addTask = () => {
+    if (!input.trim()) return;
+    const newTask: StudyTask = {
+      id: Date.now(),
+      title: input.trim(),
+      completed: false,
+    };
+    setTasks([...tasks, newTask]);
+    setInput('');
+  };
+
+  const toggleTask = (id: number) => {
+    setTasks(tasks.map(t => t.id === id ? { ...t, completed: !t.completed } : t));
+  };
+
+  const removeTask = (id: number) => {
+    setTasks(tasks.filter(t => t.id !== id));
+  };
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Study Control</h1>
+      <div className="flex mb-4 gap-2">
+        <input
+          type="text"
+          className="border rounded px-2 py-1 flex-grow"
+          placeholder="Add new task"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <Button onClick={addTask} className="bg-blue-500">
+          Add
+        </Button>
+      </div>
+      <ul className="space-y-2">
+        {tasks.map(task => (
+          <li key={task.id} className="flex items-center justify-between bg-gray-100 p-2 rounded">
+            <div className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={task.completed}
+                onChange={() => toggleTask(task.id)}
+              />
+              <span className={task.completed ? 'line-through' : ''}>{task.title}</span>
+            </div>
+            <Button
+              onClick={() => removeTask(task.id)}
+              className="bg-red-500 hover:bg-red-600"
+            >
+              Remove
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,12 @@
+import { ButtonHTMLAttributes } from 'react';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export function Button({ className = '', ...props }: ButtonProps) {
+  return (
+    <button
+      className={`inline-flex items-center justify-center rounded-md bg-blue-500 px-3 py-1 text-sm font-medium text-white hover:bg-blue-600 ${className}`}
+      {...props}
+    />
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "allowJs": true,
+    "moduleResolution": "Node",
+    "skipLibCheck": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold a basic React + Vite project
- set up Tailwind config
- add a simple Study Control App component with shadcn-styled buttons
- persist tasks to `localStorage`
- document how to run the app
