### PR TITLE
Add shadcn style sidebar

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,8 +1,28 @@
+import { HomeIcon, ListIcon, UserIcon, CogIcon } from './icons';
+
 export default function Sidebar() {
+  const link =
+    'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100';
   return (
-    <aside className="w-48 bg-gray-100 p-4 space-y-2">
-      <a href="#" className="block p-2 rounded hover:bg-gray-200">Home</a>
-      {/* More links could go here */}
+    <aside className="hidden w-64 shrink-0 border-r bg-gray-50 md:block">
+      <nav className="grid gap-1 p-4">
+        <a href="#" className={link}>
+          <HomeIcon className="h-4 w-4" />
+          Dashboard
+        </a>
+        <a href="#" className={link}>
+          <ListIcon className="h-4 w-4" />
+          Tasks
+        </a>
+        <a href="#" className={link}>
+          <UserIcon className="h-4 w-4" />
+          Users
+        </a>
+        <a href="#" className={link}>
+          <CogIcon className="h-4 w-4" />
+          Settings
+        </a>
+      </nav>
     </aside>
   );
 }

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,0 +1,35 @@
+import { SVGProps } from 'react';
+
+export function HomeIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" {...props}>
+      <path d="M3 10.5L12 3l9 7.5v10.5a1 1 0 0 1-1 1h-5v-5h-6v5H4a1 1 0 0 1-1-1V10.5z" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+export function ListIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" {...props}>
+      <path d="M4 6h16M4 12h16M4 18h16" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function UserIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" {...props}>
+      <circle cx="12" cy="7" r="4" strokeWidth="2" />
+      <path d="M5 21v-1a7 7 0 0 1 14 0v1" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function CogIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" {...props}>
+      <circle cx="12" cy="12" r="3" strokeWidth="2" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add simple SVG icons
- update sidebar to mimic shadcn dashboard layout

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687061c138148330982c6062adf13e7c