### PR TITLE
Add logout option in sidebar

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Settings2,
   Sparkles,
   Trash2,
+  LogOut,
 } from "lucide-react"
 
 import { NavFavorites } from './nav-favorites'
@@ -20,6 +21,7 @@ import { NavMain } from './nav-main'
 import { NavSecondary } from './nav-secondary'
 import { NavWorkspaces } from './nav-workspaces'
 import { TeamSwitcher } from './team-switcher'
+import { logout } from '@/services/authService'
 import {
   Sidebar,
   SidebarContent,
@@ -95,6 +97,11 @@ const data = {
       title: "Help",
       url: "#",
       icon: MessageCircleQuestion,
+    },
+    {
+      title: "Sair",
+      icon: LogOut,
+      onClick: () => logout(),
     },
   ],
   favorites: [

--- a/src/components/nav-secondary.tsx
+++ b/src/components/nav-secondary.tsx
@@ -16,9 +16,10 @@ export function NavSecondary({
 }: {
     items: {
         title: string
-        url: string
+        url?: string
         icon: LucideIcon
         badge?: React.ReactNode
+        onClick?: () => void
     }[]
 } & React.ComponentPropsWithoutRef<typeof SidebarGroup>) {
     return (
@@ -28,7 +29,7 @@ export function NavSecondary({
                     {items.map((item) => (
                         <SidebarMenuItem key={item.title}>
                             <SidebarMenuButton asChild>
-                                <a href={item.url}>
+                                <a href={item.url ?? "#"} onClick={item.onClick}>
                                     <item.icon />
                                     <span>{item.title}</span>
                                 </a>


### PR DESCRIPTION
## Summary
- allow `NavSecondary` items to be clickable actions
- import logout logic into `app-sidebar` and add a "Sair" item that logs the user out