### PR TITLE
Implement hierarchy data with sidebar

### DIFF
--- a/src/components/FormularioAtividade.tsx
+++ b/src/components/FormularioAtividade.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+import { adicionarAtividade } from '../services/atividadesService'
+
+function FormularioAtividade() {
+  const [nome, setNome] = useState('')
+  const [topicoId, setTopicoId] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!nome || !topicoId) return
+    try {
+      await adicionarAtividade({ nome, topicoId })
+      setNome('')
+    } catch (err) {
+      console.error('Erro ao adicionar atividade:', err)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h3>Adicionar Atividade</h3>
+      <input value={nome} onChange={e => setNome(e.target.value)} placeholder="Nome" />
+      <input value={topicoId} onChange={e => setTopicoId(e.target.value)} placeholder="ID do Tópico" />
+      <button type="submit">Salvar</button>
+    </form>
+  )
+}
+
+export default FormularioAtividade

--- a/src/components/FormularioMateria.tsx
+++ b/src/components/FormularioMateria.tsx
@@ -1,22 +1,23 @@
-import { useState } from 'react';
+import { useState } from 'react'
 // Importe a função do seu serviço
-import { adicionarMateria } from '../services/materiasService';
+import { adicionarMateria } from '../services/materiasService'
 
 function FormularioMateria() {
-    const [nome, setNome] = useState('');
-    const [professor, setProfessor] = useState('');
+    const [nome, setNome] = useState('')
+    const [professor, setProfessor] = useState('')
+    const [organizacaoId, setOrganizacaoId] = useState('')
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault(); // Previne o recarregamento da página
 
-        if (!nome || !professor) {
+        if (!nome || !professor || !organizacaoId) {
             alert("Por favor, preencha todos os campos.");
             return;
         }
 
         try {
             // Chama a função do serviço para adicionar a matéria
-            await adicionarMateria({ nome, professor });
+            await adicionarMateria({ nome, professor, organizacaoId });
             alert("Matéria adicionada com sucesso!");
             // Limpa os campos do formulário após o sucesso
             setNome('');
@@ -44,6 +45,14 @@ function FormularioMateria() {
                     type="text"
                     value={professor}
                     onChange={(e) => setProfessor(e.target.value)}
+                />
+            </div>
+            <div>
+                <label>ID da Organização:</label>
+                <input
+                    type="text"
+                    value={organizacaoId}
+                    onChange={(e) => setOrganizacaoId(e.target.value)}
                 />
             </div>
             <button type="submit">Salvar Matéria</button>

--- a/src/components/FormularioOrganizacao.tsx
+++ b/src/components/FormularioOrganizacao.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+import { adicionarOrganizacao } from '../services/organizacoesService'
+
+function FormularioOrganizacao() {
+  const [nome, setNome] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!nome) return
+    try {
+      await adicionarOrganizacao({ nome })
+      setNome('')
+    } catch (err) {
+      console.error('Erro ao adicionar organização:', err)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h3>Adicionar Organização</h3>
+      <input value={nome} onChange={e => setNome(e.target.value)} placeholder="Nome" />
+      <button type="submit">Salvar</button>
+    </form>
+  )
+}
+
+export default FormularioOrganizacao

--- a/src/components/FormularioTopico.tsx
+++ b/src/components/FormularioTopico.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+import { adicionarTopico } from '../services/topicosService'
+
+function FormularioTopico() {
+  const [nome, setNome] = useState('')
+  const [materiaId, setMateriaId] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!nome || !materiaId) return
+    try {
+      await adicionarTopico({ nome, materiaId })
+      setNome('')
+    } catch (err) {
+      console.error('Erro ao adicionar tópico:', err)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h3>Adicionar Tópico</h3>
+      <input value={nome} onChange={e => setNome(e.target.value)} placeholder="Nome" />
+      <input value={materiaId} onChange={e => setMateriaId(e.target.value)} placeholder="ID da Matéria" />
+      <button type="submit">Salvar</button>
+    </form>
+  )
+}
+
+export default FormularioTopico

--- a/src/components/ListaDeMaterias.tsx
+++ b/src/components/ListaDeMaterias.tsx
@@ -1,8 +1,11 @@
 import { useState, useEffect } from 'react';
 // Importa as funções do seu novo serviço e o tipo Materia!
-import { fetchMaterias, Materia } from '../services/materiasService';
+import { fetchMaterias, Materia } from '../services/materiasService'
 
-function ListaDeMaterias() {
+interface Props {
+    organizacaoId: string
+}
+function ListaDeMaterias({ organizacaoId }: Props) {
     const [materias, setMaterias] = useState<Materia[]>([]);
     const [loading, setLoading] = useState(true);
 
@@ -10,7 +13,7 @@ function ListaDeMaterias() {
         const carregarDados = async () => {
             try {
                 // Usa a função do serviço para buscar os dados
-                const dados = await fetchMaterias();
+                const dados = await fetchMaterias(organizacaoId);
                 setMaterias(dados);
             } catch (error) {
                 console.error("Erro no componente ao buscar matérias:", error);
@@ -20,7 +23,7 @@ function ListaDeMaterias() {
         };
 
         carregarDados();
-    }, []);
+    }, [organizacaoId]);
 
     if (loading) {
         return <p>Carregando...</p>;

--- a/src/components/NavHierarchy.tsx
+++ b/src/components/NavHierarchy.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from 'react'
+import { fetchOrganizacoes, Organizacao } from '../services/organizacoesService'
+import { fetchMaterias, Materia } from '../services/materiasService'
+import { fetchTopicos, Topico } from '../services/topicosService'
+import { fetchAtividades, Atividade } from '../services/atividadesService'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+} from '@/components/ui/sidebar'
+import { ChevronRight, Plus } from 'lucide-react'
+
+interface Hierarquia extends Organizacao {
+  materias: (Materia & { topicos: (Topico & { atividades: Atividade[] })[] })[]
+}
+
+export default function NavHierarchy() {
+  const [dados, setDados] = useState<Hierarquia[]>([])
+
+  useEffect(() => {
+    const carregar = async () => {
+      const orgs = await fetchOrganizacoes()
+      const orgData: Hierarquia[] = []
+      for (const org of orgs) {
+        const materias = await fetchMaterias(org.id)
+        const matData = []
+        for (const mat of materias) {
+          const topicos = await fetchTopicos(mat.id)
+          const topData = []
+          for (const top of topicos) {
+            const atividades = await fetchAtividades(top.id)
+            topData.push({ ...top, atividades })
+          }
+          matData.push({ ...mat, topicos: topData })
+        }
+        orgData.push({ ...org, materias: matData })
+      }
+      setDados(orgData)
+    }
+    carregar()
+  }, [])
+
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>Organizações</SidebarGroupLabel>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {dados.map(org => (
+            <Collapsible key={org.id}>
+              <SidebarMenuItem>
+                <SidebarMenuButton asChild>
+                  <a href="#">
+                    <span>{org.nome}</span>
+                  </a>
+                </SidebarMenuButton>
+                <CollapsibleTrigger asChild>
+                  <SidebarMenuAction className="left-2" showOnHover>
+                    <ChevronRight />
+                  </SidebarMenuAction>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <SidebarMenuSub>
+                    {org.materias.map(mat => (
+                      <SidebarMenuSubItem key={mat.id}>
+                        <Collapsible>
+                          <SidebarMenuSubButton asChild>
+                            <a href="#">
+                              <span>{mat.nome}</span>
+                            </a>
+                          </SidebarMenuSubButton>
+                          <CollapsibleTrigger asChild>
+                            <SidebarMenuAction className="left-2" showOnHover>
+                              <ChevronRight />
+                            </SidebarMenuAction>
+                          </CollapsibleTrigger>
+                          <CollapsibleContent>
+                            <SidebarMenuSub>
+                              {mat.topicos.map(top => (
+                                <SidebarMenuSubItem key={top.id}>
+                                  <Collapsible>
+                                    <SidebarMenuSubButton asChild size="sm">
+                                      <a href="#">
+                                        <span>{top.nome}</span>
+                                      </a>
+                                    </SidebarMenuSubButton>
+                                    <CollapsibleTrigger asChild>
+                                      <SidebarMenuAction className="left-2" showOnHover>
+                                        <ChevronRight />
+                                      </SidebarMenuAction>
+                                    </CollapsibleTrigger>
+                                    <CollapsibleContent>
+                                      <SidebarMenuSub>
+                                        {top.atividades.map(act => (
+                                          <SidebarMenuSubItem key={act.id}>
+                                            <SidebarMenuSubButton asChild size="sm">
+                                              <a href="#">
+                                                <span>{act.nome}</span>
+                                              </a>
+                                            </SidebarMenuSubButton>
+                                          </SidebarMenuSubItem>
+                                        ))}
+                                      </SidebarMenuSub>
+                                    </CollapsibleContent>
+                                  </Collapsible>
+                                </SidebarMenuSubItem>
+                              ))}
+                            </SidebarMenuSub>
+                          </CollapsibleContent>
+                        </Collapsible>
+                      </SidebarMenuSubItem>
+                    ))}
+                  </SidebarMenuSub>
+                </CollapsibleContent>
+              </SidebarMenuItem>
+            </Collapsible>
+          ))}
+          <SidebarMenuItem>
+            <SidebarMenuButton className="text-sidebar-foreground/70">
+              <Plus />
+              <span>More</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  )
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -20,6 +20,7 @@ import { NavFavorites } from './nav-favorites'
 import { NavMain } from './nav-main'
 import { NavSecondary } from './nav-secondary'
 import { NavWorkspaces } from './nav-workspaces'
+import NavHierarchy from './NavHierarchy'
 import { TeamSwitcher } from './team-switcher'
 import { logout } from '@/services/authService'
 import {
@@ -274,6 +275,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       </SidebarHeader>
       <SidebarContent>
         <NavFavorites favorites={data.favorites} />
+        <NavHierarchy />
         <NavWorkspaces workspaces={data.workspaces} />
         <NavSecondary items={data.navSecondary} className="mt-auto" />
       </SidebarContent>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,7 +3,11 @@ import { collection, getDocs, addDoc, updateDoc, deleteDoc, doc } from 'firebase
 import { db, auth } from '@/firebase';
 import { onAuthStateChanged, User } from 'firebase/auth';
 import { Button } from '@/components/ui/Button';
-import Sidebar from '@/components/sidebar/page';
+import Sidebar from '@/components/sidebar/page'
+import FormularioOrganizacao from '@/components/FormularioOrganizacao'
+import FormularioMateria from '@/components/FormularioMateria'
+import FormularioTopico from '@/components/FormularioTopico'
+import FormularioAtividade from '@/components/FormularioAtividade'
 
 interface StudyTask {
   id: string;
@@ -78,6 +82,13 @@ function Dashboard() {
             </li>
           ))}
         </ul>
+
+        <div className="mt-8 space-y-4">
+          <FormularioOrganizacao />
+          <FormularioMateria />
+          <FormularioTopico />
+          <FormularioAtividade />
+        </div>
       </div>
     </>
 

--- a/src/services/atividadesService.ts
+++ b/src/services/atividadesService.ts
@@ -1,0 +1,23 @@
+import { db } from '@/firebase'
+import { collection, getDocs, addDoc, query, where } from 'firebase/firestore'
+
+export interface Atividade {
+  id: string
+  nome: string
+  topicoId: string
+}
+
+const atividadesCollection = collection(db, 'atividades')
+
+export const fetchAtividades = async (topicoId: string): Promise<Atividade[]> => {
+  const q = query(atividadesCollection, where('topicoId', '==', topicoId))
+  const snapshot = await getDocs(q)
+  return snapshot.docs.map(doc => ({
+    id: doc.id,
+    ...(doc.data() as Omit<Atividade, 'id'>),
+  }))
+}
+
+export const adicionarAtividade = async (nova: Omit<Atividade, 'id'>) => {
+  return addDoc(atividadesCollection, nova)
+}

--- a/src/services/materiasService.ts
+++ b/src/services/materiasService.ts
@@ -1,19 +1,23 @@
 import { db } from '@/firebase';
-import { collection, getDocs, addDoc, doc, updateDoc, deleteDoc } from 'firebase/firestore';
+import { collection, getDocs, addDoc, doc, updateDoc, deleteDoc, query, where } from 'firebase/firestore';
 
 // Definindo o tipo para os dados da Matéria
 export interface Materia {
   id: string;
   nome: string;
   professor: string;
+  organizacaoId: string;
 }
 
 // Referência para a coleção "materias"
 const materiasCollectionRef = collection(db, 'materias');
 
-// FUNÇÃO PARA BUSCAR TODAS AS MATÉRIAS
-export const fetchMaterias = async (): Promise<Materia[]> => {
-  const querySnapshot = await getDocs(materiasCollectionRef);
+// FUNÇÃO PARA BUSCAR MATÉRIAS. PODE FILTRAR POR ORGANIZAÇÃO SE O ID FOR PASSADO
+export const fetchMaterias = async (organizacaoId?: string): Promise<Materia[]> => {
+  const materiasQuery = organizacaoId
+    ? query(materiasCollectionRef, where('organizacaoId', '==', organizacaoId))
+    : materiasCollectionRef
+  const querySnapshot = await getDocs(materiasQuery);
   const materiasList = querySnapshot.docs.map(doc => ({
     id: doc.id,
     ...doc.data()

--- a/src/services/organizacoesService.ts
+++ b/src/services/organizacoesService.ts
@@ -1,0 +1,21 @@
+import { db } from '@/firebase'
+import { collection, getDocs, addDoc } from 'firebase/firestore'
+
+export interface Organizacao {
+  id: string
+  nome: string
+}
+
+const organizacoesCollection = collection(db, 'organizacoes')
+
+export const fetchOrganizacoes = async (): Promise<Organizacao[]> => {
+  const snapshot = await getDocs(organizacoesCollection)
+  return snapshot.docs.map(doc => ({
+    id: doc.id,
+    ...(doc.data() as Omit<Organizacao, 'id'>),
+  }))
+}
+
+export const adicionarOrganizacao = async (nova: Omit<Organizacao, 'id'>) => {
+  return addDoc(organizacoesCollection, nova)
+}

--- a/src/services/topicosService.ts
+++ b/src/services/topicosService.ts
@@ -1,0 +1,23 @@
+import { db } from '@/firebase'
+import { collection, getDocs, addDoc, query, where } from 'firebase/firestore'
+
+export interface Topico {
+  id: string
+  nome: string
+  materiaId: string
+}
+
+const topicosCollection = collection(db, 'topicos')
+
+export const fetchTopicos = async (materiaId: string): Promise<Topico[]> => {
+  const q = query(topicosCollection, where('materiaId', '==', materiaId))
+  const snapshot = await getDocs(q)
+  return snapshot.docs.map(doc => ({
+    id: doc.id,
+    ...(doc.data() as Omit<Topico, 'id'>),
+  }))
+}
+
+export const adicionarTopico = async (novo: Omit<Topico, 'id'>) => {
+  return addDoc(topicosCollection, novo)
+}


### PR DESCRIPTION
## Summary
- add services for organizacoes, materias, topicos and atividades
- add forms to create hierarchy data
- display hierarchy in sidebar
- include forms in Dashboard

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6871295c10648330a3e4d88d1ef0c682