### PR TITLE
Implement organization-based navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,18 +4,21 @@ import PrivateRoute from '@/components/PrivateRoute';
 import Login from '@/Login';
 import Dashboard from '@/pages/Dashboard';
 import Sidebar from './components/sidebar/page';
+import { OrganizacaoProvider } from './contexts/OrganizacaoContext';
 
 export default function App() {
   return (
     <AuthProvider>
-      <Sidebar >
-        <Router>
-          <Routes>
-            <Route path="/login" element={<Login />} />
+      <OrganizacaoProvider>
+        <Sidebar>
+          <Router>
+            <Routes>
+              <Route path="/login" element={<Login />} />
             <Route path="/*" element={<PrivateRoute><Dashboard /></PrivateRoute>} />
-          </Routes>
-        </Router>
-      </Sidebar>
+            </Routes>
+          </Router>
+        </Sidebar>
+      </OrganizacaoProvider>
     </AuthProvider>
   );
 }

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -32,23 +32,6 @@ import {
 
 // This is sample data.
 const data = {
-  teams: [
-    {
-      name: "Acme Inc",
-      logo: Command,
-      plan: "Enterprise",
-    },
-    {
-      name: "Acme Corp.",
-      logo: AudioWaveform,
-      plan: "Startup",
-    },
-    {
-      name: "Evil Corp.",
-      logo: Command,
-      plan: "Free",
-    },
-  ],
   navMain: [
     {
       title: "Search",
@@ -270,7 +253,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   return (
     <Sidebar className="border-r-0" {...props}>
       <SidebarHeader>
-        <TeamSwitcher teams={data.teams} />
+        <TeamSwitcher />
         <NavMain items={data.navMain} />
       </SidebarHeader>
       <SidebarContent>

--- a/src/components/team-switcher.tsx
+++ b/src/components/team-switcher.tsx
@@ -1,14 +1,13 @@
 "use client"
 
 import * as React from "react"
-import { ChevronDown, Plus } from "lucide-react"
+import { ChevronDown, Building2 } from "lucide-react"
 
 import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
     DropdownMenuLabel,
-    DropdownMenuSeparator,
     DropdownMenuShortcut,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
@@ -18,16 +17,11 @@ import {
     SidebarMenuItem,
 } from '@/components/ui/sidebar'
 
-export function TeamSwitcher({
-    teams,
-}: {
-    teams: {
-        name: string
-        logo: React.ElementType
-        plan: string
-    }[]
-}) {
-    const [activeTeam, setActiveTeam] = React.useState(teams[0])
+import { useOrganizacao } from "@/contexts/OrganizacaoContext"
+
+export function TeamSwitcher() {
+    const { organizacoes, activeOrganizacao, setActiveOrganizacao } = useOrganizacao()
+    const activeTeam = activeOrganizacao || organizacoes[0]
 
     if (!activeTeam) {
         return null
@@ -40,9 +34,9 @@ export function TeamSwitcher({
                     <DropdownMenuTrigger asChild>
                         <SidebarMenuButton className="w-fit px-1.5">
                             <div className="flex aspect-square size-5 items-center justify-center rounded-md bg-sidebar-primary text-sidebar-primary-foreground">
-                                <activeTeam.logo className="size-3" />
+                                <Building2 className="size-3" />
                             </div>
-                            <span className="truncate font-semibold">{activeTeam.name}</span>
+                            <span className="truncate font-semibold">{activeTeam.nome}</span>
                             <ChevronDown className="opacity-50" />
                         </SidebarMenuButton>
                     </DropdownMenuTrigger>
@@ -53,28 +47,21 @@ export function TeamSwitcher({
                         sideOffset={4}
                     >
                         <DropdownMenuLabel className="text-xs text-muted-foreground">
-                            Teams
+                            Organizações
                         </DropdownMenuLabel>
-                        {teams.map((team, index) => (
+                        {organizacoes.map((org, index) => (
                             <DropdownMenuItem
-                                key={team.name}
-                                onClick={() => setActiveTeam(team)}
+                                key={org.id}
+                                onClick={() => setActiveOrganizacao(org)}
                                 className="gap-2 p-2"
                             >
                                 <div className="flex size-6 items-center justify-center rounded-sm border">
-                                    <team.logo className="size-4 shrink-0" />
+                                    <span className="text-xs font-medium">{index + 1}</span>
                                 </div>
-                                {team.name}
+                                {org.nome}
                                 <DropdownMenuShortcut>⌘{index + 1}</DropdownMenuShortcut>
                             </DropdownMenuItem>
                         ))}
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem className="gap-2 p-2">
-                            <div className="flex size-6 items-center justify-center rounded-md border bg-background">
-                                <Plus className="size-4" />
-                            </div>
-                            <div className="font-medium text-muted-foreground">Add team</div>
-                        </DropdownMenuItem>
                     </DropdownMenuContent>
                 </DropdownMenu>
             </SidebarMenuItem>

--- a/src/contexts/OrganizacaoContext.tsx
+++ b/src/contexts/OrganizacaoContext.tsx
@@ -1,0 +1,46 @@
+import { createContext, ReactNode, useContext, useEffect, useState } from 'react'
+import { fetchOrganizacoes, Organizacao } from '@/services/organizacoesService'
+
+interface OrganizacaoContextValue {
+  organizacoes: Organizacao[]
+  activeOrganizacao: Organizacao | null
+  setActiveOrganizacao: (org: Organizacao) => void
+}
+
+const OrganizacaoContext = createContext<OrganizacaoContextValue | undefined>(
+  undefined
+)
+
+export function OrganizacaoProvider({ children }: { children: ReactNode }) {
+  const [organizacoes, setOrganizacoes] = useState<Organizacao[]>([])
+  const [activeOrganizacao, setActiveOrganizacao] = useState<Organizacao | null>(
+    null
+  )
+
+  useEffect(() => {
+    const carregar = async () => {
+      const orgs = await fetchOrganizacoes()
+      setOrganizacoes(orgs)
+      if (!activeOrganizacao && orgs.length > 0) {
+        setActiveOrganizacao(orgs[0])
+      }
+    }
+    carregar()
+  }, [activeOrganizacao])
+
+  return (
+    <OrganizacaoContext.Provider
+      value={{ organizacoes, activeOrganizacao, setActiveOrganizacao }}
+    >
+      {children}
+    </OrganizacaoContext.Provider>
+  )
+}
+
+export function useOrganizacao() {
+  const ctx = useContext(OrganizacaoContext)
+  if (!ctx) {
+    throw new Error('useOrganizacao must be used within OrganizacaoProvider')
+  }
+  return ctx
+}


### PR DESCRIPTION
## Summary
- wrap the app with `OrganizacaoProvider`
- load organizations in `TeamSwitcher` and switch between them
- show hierarchy of matérias, tópicos and atividades for the selected organization
