### PR TITLE
Add settings page for managing entities

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { AuthProvider } from '@/contexts/AuthContext';
 import PrivateRoute from '@/components/PrivateRoute';
 import Login from '@/Login';
 import Dashboard from '@/pages/Dashboard';
+import Settings from '@/pages/Settings';
 import Sidebar from './components/sidebar/page';
 import { OrganizacaoProvider } from './contexts/OrganizacaoContext';
 
@@ -14,7 +15,14 @@ export default function App() {
           <Router>
             <Routes>
               <Route path="/login" element={<Login />} />
-            <Route path="/*" element={<PrivateRoute><Dashboard /></PrivateRoute>} />
+              <Route
+                path="/"
+                element={<PrivateRoute><Dashboard /></PrivateRoute>}
+              />
+              <Route
+                path="/settings"
+                element={<PrivateRoute><Settings /></PrivateRoute>}
+              />
             </Routes>
           </Router>
         </Sidebar>

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -64,7 +64,7 @@ const data = {
     },
     {
       title: "Settings",
-      url: "#",
+      url: "/settings",
       icon: Settings2,
     },
     {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useState } from 'react'
+import {
+  fetchOrganizacoes,
+  adicionarOrganizacao,
+  deletarOrganizacao,
+  Organizacao,
+} from '@/services/organizacoesService'
+import {
+  fetchMaterias,
+  adicionarMateria,
+  deletarMateria,
+  Materia,
+} from '@/services/materiasService'
+import {
+  fetchTodosTopicos,
+  adicionarTopico,
+  deletarTopico,
+  Topico,
+} from '@/services/topicosService'
+import {
+  fetchTodasAtividades,
+  adicionarAtividade,
+  deletarAtividade,
+  Atividade,
+} from '@/services/atividadesService'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/Button'
+
+export default function Settings() {
+  const [orgs, setOrgs] = useState<Organizacao[]>([])
+  const [novoOrg, setNovoOrg] = useState('')
+
+  const [materias, setMaterias] = useState<Materia[]>([])
+  const [novaMateria, setNovaMateria] = useState({
+    nome: '',
+    professor: '',
+    organizacaoId: '',
+  })
+
+  const [topicos, setTopicos] = useState<Topico[]>([])
+  const [novoTopico, setNovoTopico] = useState({ nome: '', materiaId: '' })
+
+  const [atividades, setAtividades] = useState<Atividade[]>([])
+  const [novaAtividade, setNovaAtividade] = useState({ nome: '', topicoId: '' })
+
+  const carregar = async () => {
+    const [o, m, t, a] = await Promise.all([
+      fetchOrganizacoes(),
+      fetchMaterias(),
+      fetchTodosTopicos(),
+      fetchTodasAtividades(),
+    ])
+    setOrgs(o)
+    setMaterias(m)
+    setTopicos(t)
+    setAtividades(a)
+  }
+
+  useEffect(() => {
+    carregar()
+  }, [])
+
+  const addOrganizacao = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!novoOrg) return
+    await adicionarOrganizacao({ nome: novoOrg })
+    setNovoOrg('')
+    carregar()
+  }
+
+  const addMateria = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const { nome, professor, organizacaoId } = novaMateria
+    if (!nome || !professor || !organizacaoId) return
+    await adicionarMateria(novaMateria)
+    setNovaMateria({ nome: '', professor: '', organizacaoId: '' })
+    carregar()
+  }
+
+  const addTopico = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const { nome, materiaId } = novoTopico
+    if (!nome || !materiaId) return
+    await adicionarTopico(novoTopico)
+    setNovoTopico({ nome: '', materiaId: '' })
+    carregar()
+  }
+
+  const addAtividade = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const { nome, topicoId } = novaAtividade
+    if (!nome || !topicoId) return
+    await adicionarAtividade(novaAtividade)
+    setNovaAtividade({ nome: '', topicoId: '' })
+    carregar()
+  }
+
+  return (
+    <div className="space-y-8">
+      <section>
+        <h2 className="text-lg font-semibold mb-2">Organizações</h2>
+        <form onSubmit={addOrganizacao} className="flex gap-2 mb-2">
+          <Input
+            value={novoOrg}
+            onChange={e => setNovoOrg(e.target.value)}
+            placeholder="Nome da organização"
+          />
+          <Button type="submit">Adicionar</Button>
+        </form>
+        <ul className="space-y-1">
+          {orgs.map(org => (
+            <li key={org.id} className="flex justify-between gap-2">
+              <span>{org.nome}</span>
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={() => {
+                  deletarOrganizacao(org.id).then(carregar)
+                }}
+              >
+                Excluir
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold mb-2">Matérias</h2>
+        <form onSubmit={addMateria} className="flex flex-col gap-2 mb-2">
+          <Input
+            value={novaMateria.nome}
+            onChange={e => setNovaMateria({ ...novaMateria, nome: e.target.value })}
+            placeholder="Nome"
+          />
+          <Input
+            value={novaMateria.professor}
+            onChange={e =>
+              setNovaMateria({ ...novaMateria, professor: e.target.value })
+            }
+            placeholder="Professor"
+          />
+          <Input
+            value={novaMateria.organizacaoId}
+            onChange={e =>
+              setNovaMateria({ ...novaMateria, organizacaoId: e.target.value })
+            }
+            placeholder="ID da Organização"
+          />
+          <Button type="submit">Adicionar</Button>
+        </form>
+        <ul className="space-y-1">
+          {materias.map(mat => (
+            <li key={mat.id} className="flex justify-between gap-2">
+              <span>
+                {mat.nome} - {mat.organizacaoId}
+              </span>
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={() => {
+                  deletarMateria(mat.id).then(carregar)
+                }}
+              >
+                Excluir
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold mb-2">Tópicos</h2>
+        <form onSubmit={addTopico} className="flex flex-col gap-2 mb-2">
+          <Input
+            value={novoTopico.nome}
+            onChange={e => setNovoTopico({ ...novoTopico, nome: e.target.value })}
+            placeholder="Nome"
+          />
+          <Input
+            value={novoTopico.materiaId}
+            onChange={e =>
+              setNovoTopico({ ...novoTopico, materiaId: e.target.value })
+            }
+            placeholder="ID da Matéria"
+          />
+          <Button type="submit">Adicionar</Button>
+        </form>
+        <ul className="space-y-1">
+          {topicos.map(top => (
+            <li key={top.id} className="flex justify-between gap-2">
+              <span>
+                {top.nome} - {top.materiaId}
+              </span>
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={() => {
+                  deletarTopico(top.id).then(carregar)
+                }}
+              >
+                Excluir
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold mb-2">Atividades</h2>
+        <form onSubmit={addAtividade} className="flex flex-col gap-2 mb-2">
+          <Input
+            value={novaAtividade.nome}
+            onChange={e =>
+              setNovaAtividade({ ...novaAtividade, nome: e.target.value })
+            }
+            placeholder="Nome"
+          />
+          <Input
+            value={novaAtividade.topicoId}
+            onChange={e =>
+              setNovaAtividade({ ...novaAtividade, topicoId: e.target.value })
+            }
+            placeholder="ID do Tópico"
+          />
+          <Button type="submit">Adicionar</Button>
+        </form>
+        <ul className="space-y-1">
+          {atividades.map(act => (
+            <li key={act.id} className="flex justify-between gap-2">
+              <span>
+                {act.nome} - {act.topicoId}
+              </span>
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={() => {
+                  deletarAtividade(act.id).then(carregar)
+                }}
+              >
+                Excluir
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/src/services/atividadesService.ts
+++ b/src/services/atividadesService.ts
@@ -1,5 +1,5 @@
 import { db } from '@/firebase'
-import { collection, getDocs, addDoc, query, where } from 'firebase/firestore'
+import { collection, getDocs, addDoc, query, where, deleteDoc, doc } from 'firebase/firestore'
 
 export interface Atividade {
   id: string
@@ -18,6 +18,19 @@ export const fetchAtividades = async (topicoId: string): Promise<Atividade[]> =>
   }))
 }
 
+export const fetchTodasAtividades = async (): Promise<Atividade[]> => {
+  const snapshot = await getDocs(atividadesCollection)
+  return snapshot.docs.map(doc => ({
+    id: doc.id,
+    ...(doc.data() as Omit<Atividade, 'id'>),
+  }))
+}
+
 export const adicionarAtividade = async (nova: Omit<Atividade, 'id'>) => {
   return addDoc(atividadesCollection, nova)
+}
+
+export const deletarAtividade = async (id: string) => {
+  const ref = doc(db, 'atividades', id)
+  await deleteDoc(ref)
 }

--- a/src/services/organizacoesService.ts
+++ b/src/services/organizacoesService.ts
@@ -1,5 +1,5 @@
 import { db } from '@/firebase'
-import { collection, getDocs, addDoc } from 'firebase/firestore'
+import { collection, getDocs, addDoc, deleteDoc, doc } from 'firebase/firestore'
 
 export interface Organizacao {
   id: string
@@ -18,4 +18,9 @@ export const fetchOrganizacoes = async (): Promise<Organizacao[]> => {
 
 export const adicionarOrganizacao = async (nova: Omit<Organizacao, 'id'>) => {
   return addDoc(organizacoesCollection, nova)
+}
+
+export const deletarOrganizacao = async (id: string) => {
+  const ref = doc(db, 'organizacoes', id)
+  await deleteDoc(ref)
 }

--- a/src/services/topicosService.ts
+++ b/src/services/topicosService.ts
@@ -1,5 +1,5 @@
 import { db } from '@/firebase'
-import { collection, getDocs, addDoc, query, where } from 'firebase/firestore'
+import { collection, getDocs, addDoc, query, where, deleteDoc, doc } from 'firebase/firestore'
 
 export interface Topico {
   id: string
@@ -18,6 +18,19 @@ export const fetchTopicos = async (materiaId: string): Promise<Topico[]> => {
   }))
 }
 
+export const fetchTodosTopicos = async (): Promise<Topico[]> => {
+  const snapshot = await getDocs(topicosCollection)
+  return snapshot.docs.map(doc => ({
+    id: doc.id,
+    ...(doc.data() as Omit<Topico, 'id'>),
+  }))
+}
+
 export const adicionarTopico = async (novo: Omit<Topico, 'id'>) => {
   return addDoc(topicosCollection, novo)
+}
+
+export const deletarTopico = async (id: string) => {
+  const ref = doc(db, 'topicos', id)
+  await deleteDoc(ref)
 }


### PR DESCRIPTION
## Summary
- create `Settings` page to manage organizations, subjects, topics and activities
- expose routes for `/settings`
- link the "Settings" sidebar item to the new route
- add delete helpers and fetch-all helpers for services
