### PR TITLE
Add generic subject details page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import PrivateRoute from '@/components/PrivateRoute';
 import Login from '@/Login';
 import Dashboard from '@/pages/Dashboard';
 import Settings from '@/pages/Settings';
+import MateriaDetails from '@/pages/MateriaDetails';
 import Sidebar from './components/sidebar/page';
 import { OrganizacaoProvider } from './contexts/OrganizacaoContext';
 
@@ -22,6 +23,10 @@ export default function App() {
               <Route
                 path="/settings"
                 element={<PrivateRoute><Settings /></PrivateRoute>}
+              />
+              <Route
+                path="/materia/:id"
+                element={<PrivateRoute><MateriaDetails /></PrivateRoute>}
               />
             </Routes>
           </Router>

--- a/src/components/nav-materias.tsx
+++ b/src/components/nav-materias.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { fetchMaterias, Materia } from '@/services/materiasService'
 import { useOrganizacao } from '@/contexts/OrganizacaoContext'
 import {
@@ -36,10 +37,10 @@ export function NavMaterias() {
           {materias.map(mat => (
             <SidebarMenuItem key={mat.id}>
               <SidebarMenuButton asChild>
-                <a href="#">
+                <Link to={`/materia/${mat.id}`}>
                   <span>{mat.emoji ?? '📚'}</span>
                   <span>{mat.nome}</span>
-                </a>
+                </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>
           ))}

--- a/src/pages/MateriaDetails.tsx
+++ b/src/pages/MateriaDetails.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { Materia, fetchMateriaById } from '@/services/materiasService'
+import { fetchTopicos, Topico } from '@/services/topicosService'
+
+export default function MateriaDetails() {
+  const { id } = useParams()
+  const [materia, setMateria] = useState<Materia | null>(null)
+  const [topicos, setTopicos] = useState<Topico[]>([])
+
+  useEffect(() => {
+    const load = async () => {
+      if (!id) return
+      const mat = await fetchMateriaById(id)
+      setMateria(mat)
+      if (mat) {
+        const tops = await fetchTopicos(mat.id)
+        setTopicos(tops)
+      }
+    }
+    load()
+  }, [id])
+
+  if (!materia) {
+    return <p>Carregando...</p>
+  }
+
+  const totalTopicos = topicos.length
+  const topicosEstudados = Math.floor(totalTopicos / 2)
+  const topicosRestantes = totalTopicos - topicosEstudados
+
+  const tempoPrevisto = totalTopicos * 60 // minutos
+  const tempoEstudado = topicosEstudados * 45
+
+  const questoesFeitas = 50
+  const questoesAcertadas = 35
+  const questoesErradas = questoesFeitas - questoesAcertadas
+
+  const percentualDesempenho = Math.round(
+    (questoesAcertadas / (questoesFeitas || 1)) * 100
+  )
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">{materia.nome}</h1>
+
+      <section className="space-y-2">
+        <h2 className="text-lg font-semibold">Desempenho</h2>
+        <div className="w-full h-4 bg-gray-200 rounded">
+          <div
+            className="h-full bg-green-500 rounded"
+            style={{ width: `${percentualDesempenho}%` }}
+          />
+        </div>
+        <p>{percentualDesempenho}% de acertos</p>
+        <ul className="list-disc pl-4">
+          <li>Questões respondidas: {questoesFeitas}</li>
+          <li>Acertos: {questoesAcertadas}</li>
+          <li>Erros: {questoesErradas}</li>
+        </ul>
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="text-lg font-semibold">Tópicos</h2>
+        <ul className="list-disc pl-4">
+          <li>Total: {totalTopicos}</li>
+          <li>Estudados: {topicosEstudados}</li>
+          <li>Restantes: {topicosRestantes}</li>
+        </ul>
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="text-lg font-semibold">Tempo de estudo</h2>
+        <ul className="list-disc pl-4">
+          <li>Previsto: {tempoPrevisto} minutos</li>
+          <li>Já estudados: {tempoEstudado} minutos</li>
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/src/services/materiasService.ts
+++ b/src/services/materiasService.ts
@@ -46,3 +46,13 @@ export const deletarMateria = async (id: string, organizacaoId: string) => {
   const materiaDoc = doc(db, 'organizacoes', organizacaoId, 'materias', id)
   await deleteDoc(materiaDoc)
 }
+
+export const fetchMateriaById = async (id: string): Promise<Materia | null> => {
+  const q = query(collectionGroup(db, 'materias'), where('__name__', '==', id))
+  const snap = await getDocs(q)
+  if (snap.empty) return null
+  const d = snap.docs[0]
+  const data = d.data() as Omit<Materia, 'id' | 'organizacaoId'>
+  const orgId = d.ref.parent.parent?.id ?? ''
+  return { id: d.id, organizacaoId: orgId, ...data }
+}


### PR DESCRIPTION
## Summary
- add a `MateriaDetails` page with generic statistics
- expose new `/materia/:id` route
- link sidebar subject items to the new route
- allow fetching a single subject by id
