### PR TITLE
Add emoji dropdown for adding a subject

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "emoji-picker-react": "^4.4.6"
   },
   "devDependencies": {
     "@types/firebase": "^2.4.32",

--- a/src/components/FormularioMateria.tsx
+++ b/src/components/FormularioMateria.tsx
@@ -1,12 +1,16 @@
 import { useState } from 'react'
-// Importe a função do seu serviço
 import { adicionarMateria } from '../services/materiasService'
+import EmojiPicker, { EmojiClickData } from 'emoji-picker-react'
 
 function FormularioMateria() {
     const [nome, setNome] = useState('')
     const [professor, setProfessor] = useState('')
     const [emoji, setEmoji] = useState('')
     const [organizacaoId, setOrganizacaoId] = useState('')
+
+    const handleEmojiClick = (emojiData: EmojiClickData) => {
+        setEmoji(emojiData.emoji)
+    }
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault(); // Previne o recarregamento da página
@@ -51,11 +55,12 @@ function FormularioMateria() {
             </div>
             <div>
                 <label>Emoji:</label>
-                <input
-                    type="text"
-                    value={emoji}
-                    onChange={(e) => setEmoji(e.target.value)}
-                />
+                <EmojiPicker onEmojiClick={handleEmojiClick} />
+                {emoji && (
+                    <div>
+                        <strong>Selecionado:</strong> {emoji}
+                    </div>
+                )}
             </div>
             <div>
                 <label>ID da Organização:</label>


### PR DESCRIPTION
## Summary
- integrate `emoji-picker-react` so users can choose from the full emoji set
- replace simple dropdown in `FormularioMateria` with the emoji picker component

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68716e52d2b08330a63458802203b4f4