### PR TITLE
Add revision scheduling calendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^4.0.5"
+    "zod": "^4.0.5",
+    "react-day-picker": "^9.0.1",
+    "date-fns": "^3.6.0"
   },
   "devDependencies": {
     "@types/firebase": "^2.4.32",

--- a/src/components/forms/AtividadeForm.tsx
+++ b/src/components/forms/AtividadeForm.tsx
@@ -1,6 +1,9 @@
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/Button'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Calendar } from '@/components/ui/calendar'
 import { Atividade } from '@/services/atividadesService'
+import { addDays } from 'date-fns'
 import React from 'react'
 
 interface FormAtividadesProps {
@@ -8,6 +11,7 @@ interface FormAtividadesProps {
   novaAtividade: string
   setNovaAtividade: (v: string) => void
   addAtividade: (e: React.FormEvent) => void
+  addRevisao: (nome: string, data: Date) => void
   editAtividade: (act: Atividade) => void
   deletarAtividade: (id: string, topicoId: string) => void
   selectedTopicoNome: string
@@ -20,12 +24,30 @@ export function FormAtividades({
   novaAtividade,
   setNovaAtividade,
   addAtividade,
+  addRevisao,
   editAtividade,
   deletarAtividade,
   selectedTopicoNome,
   onVoltar,
   BreadcrumbNav,
 }: FormAtividadesProps) {
+  const [openRevisao, setOpenRevisao] = React.useState(false)
+  const [revisaoNome, setRevisaoNome] = React.useState('')
+  const [dias, setDias] = React.useState(1)
+  const [selectedDate, setSelectedDate] = React.useState<Date>(addDays(new Date(), 1))
+
+  React.useEffect(() => {
+    setSelectedDate(addDays(new Date(), dias))
+  }, [dias])
+
+  const handleAddRevisao = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!selectedDate) return
+    addRevisao(revisaoNome || 'Revisão', selectedDate)
+    setRevisaoNome('')
+    setDias(1)
+    setOpenRevisao(false)
+  }
   return (
     <div className="space-y-8">
       <Button size="sm" variant="outline" onClick={onVoltar}>
@@ -36,14 +58,43 @@ export function FormAtividades({
         <h2 className="text-lg font-semibold mb-2">
           Atividades de {selectedTopicoNome}
         </h2>
-        <form onSubmit={addAtividade} className="flex gap-2 mb-2">
+        <form onSubmit={addAtividade} className="flex gap-2 mb-2 flex-wrap">
           <Input
             value={novaAtividade}
             onChange={e => setNovaAtividade(e.target.value)}
             placeholder="Nome da atividade"
           />
           <Button type="submit">Adicionar</Button>
+          <Button type="button" variant="outline" onClick={() => setOpenRevisao(true)}>
+            Nova revisão
+          </Button>
         </form>
+        <Dialog open={openRevisao} onOpenChange={setOpenRevisao}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Adicionar revisão</DialogTitle>
+            </DialogHeader>
+            <form onSubmit={handleAddRevisao} className="space-y-4">
+              <Input
+                value={revisaoNome}
+                onChange={e => setRevisaoNome(e.target.value)}
+                placeholder="Nome da revisão"
+              />
+              <div className="flex items-center gap-2">
+                <Input
+                  type="number"
+                  min="1"
+                  className="w-20"
+                  value={dias}
+                  onChange={e => setDias(Number(e.target.value))}
+                />
+                <span className="text-sm text-muted-foreground">dias a partir de hoje</span>
+              </div>
+              <Calendar mode="single" selected={selectedDate} onSelect={setSelectedDate} />
+              <Button type="submit" className="w-full">Adicionar revisão</Button>
+            </form>
+          </DialogContent>
+        </Dialog>
         <ul className="space-y-1">
           {atividades.map(act => (
             <li key={act.id} className="flex justify-between gap-2">
@@ -66,4 +117,4 @@ export function FormAtividades({
       </section>
     </div>
   )
-} 
+}

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,0 +1,58 @@
+import * as React from "react"
+import { ChevronLeft, ChevronRight } from "lucide-react"
+import { DayPicker } from "react-day-picker"
+import "react-day-picker/dist/style.css"
+
+import { cn } from "@/lib/utils"
+
+export type CalendarProps = React.ComponentProps<typeof DayPicker>
+
+export function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  ...props
+}: CalendarProps) {
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn("p-3", className)}
+      classNames={{
+        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
+        month: "space-y-4",
+        caption: "flex justify-center pt-1 relative items-center",
+        caption_label: "text-sm font-medium",
+        nav: "space-x-1 flex items-center",
+        nav_button: "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100",
+        nav_button_previous: "absolute left-1",
+        nav_button_next: "absolute right-1",
+        table: "w-full border-collapse space-y-1",
+        head_row: "flex",
+        head_cell:
+          "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
+        row: "flex w-full mt-2",
+        cell:
+          "text-center text-sm p-0 relative [&:has([aria-selected])]:bg-accent [&:has([aria-selected])]:text-accent-foreground first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+        day: "h-9 w-9 p-0 font-normal aria-selected:opacity-100",
+        day_selected:
+          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+        day_today: "bg-accent text-accent-foreground",
+        day_outside:
+          "text-muted-foreground opacity-50 aria-selected:bg-accent/50 aria-selected:text-muted-foreground",
+        day_disabled: "text-muted-foreground opacity-50",
+        day_range_start: "bg-accent text-accent-foreground",
+        day_range_end: "bg-accent text-accent-foreground",
+        day_range_middle:
+          "aria-selected:bg-accent aria-selected:text-accent-foreground",
+        ...classNames,
+      }}
+      components={{
+        IconLeft: () => <ChevronLeft className="h-4 w-4" />,
+        IconRight: () => <ChevronRight className="h-4 w-4" />,
+      }}
+      {...props}
+    />
+  )
+}
+Calendar.displayName = "Calendar"
+

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -228,8 +228,19 @@ export default function Settings() {
     if (!selectedTopico || !selectedMateria || !selectedOrg) return
     await adicionarAtividade(selectedOrg.id, selectedMateria.id, selectedTopico.id, {
       nome: novaAtividade,
+      tipo: 'tarefa',
     })
     setNovaAtividade('')
+    carregarAtividades()
+  }
+
+  const addRevisao = async (nome: string, data: Date) => {
+    if (!selectedTopico || !selectedMateria || !selectedOrg) return
+    await adicionarAtividade(selectedOrg.id, selectedMateria.id, selectedTopico.id, {
+      nome,
+      tipo: 'revisao',
+      data: data.toISOString(),
+    })
     carregarAtividades()
   }
 
@@ -335,6 +346,7 @@ export default function Settings() {
       novaAtividade={novaAtividade}
       setNovaAtividade={setNovaAtividade}
       addAtividade={addAtividade}
+      addRevisao={addRevisao}
       editAtividade={editAtividade}
       deletarAtividade={async (id, topicoId) => {
         await deletarAtividade(id, topicoId, selectedMateria?.id ?? '', selectedOrg?.id ?? '')

--- a/src/services/atividadesService.ts
+++ b/src/services/atividadesService.ts
@@ -7,7 +7,8 @@ import { getAuth } from 'firebase/auth'
 export interface Atividade {
   id: string
   nome: string
-  // topicoId não é mais necessário no documento
+  tipo?: 'tarefa' | 'revisao'
+  data?: string
 }
 
 // Helper para a referência da coleção


### PR DESCRIPTION
## Summary
- allow activities to store `tipo` and `data`
- add `react-day-picker` calendar component
- expand `AtividadeForm` with dialog to add revision activities
- support adding revisions from Settings page

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails: cannot find module)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_687507ddf7488330926b7da6ad8e41e1