### PR TITLE
Implement configurable revision calendar

### DIFF
--- a/src/schema/FormAtividadeSchema.ts
+++ b/src/schema/FormAtividadeSchema.ts
@@ -6,13 +6,13 @@ const AulaSchema = z.object({
   status: z.enum(["pendente", "concluído"], "Status inválido"),
 });
 
+const RevisaoItemSchema = z.object({
+  dias: z.number().min(1, "Dias deve ser no mínimo 1"),
+});
+
 const RevisaoSchema = z.object({
-  dataAtual: z.date(),
-  data24h: z.date(),
-  data7dias: z.date(),
-  data30dias: z.date(),
-  data3meses: z.date(),
-  data6meses: z.date(),
+  dataInicial: z.date(),
+  revisoes: z.array(RevisaoItemSchema).min(1, "Adicione ao menos uma revisão"),
 });
 
 const QuestoesSchema = z.object({


### PR DESCRIPTION
## Summary
- add dynamic revision scheduler for `revisao` type
- update validation schema to support custom revision days

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_687515c10a008330a601483fe43bf125