### PR TITLE
Add topic status computation

### DIFF
--- a/src/components/features/TopicoStatusPanel.tsx
+++ b/src/components/features/TopicoStatusPanel.tsx
@@ -1,0 +1,21 @@
+import { AtividadeExtended, calculateTopicoStatus } from '@/lib/topicoStatus'
+
+interface Props {
+  atividades: AtividadeExtended[]
+  topicoNome: string
+}
+
+export function TopicoStatusPanel({ atividades, topicoNome }: Props) {
+  const metrics = calculateTopicoStatus(atividades)
+  return (
+    <div className="border rounded p-4 mb-4">
+      <h2 className="text-lg font-semibold mb-2">{topicoNome}</h2>
+      <p>Status Geral: {metrics.statusGeral}</p>
+      <p>Desempenho Médio: {metrics.desempenhoMedio}%</p>
+      <p>Próxima Revisão: {metrics.proximaRevisao ? new Date(metrics.proximaRevisao).toLocaleDateString() : 'N/A'}</p>
+      <p>
+        Progresso Teórico: {metrics.progressoTeorico.concluidas} de {metrics.progressoTeorico.total}
+      </p>
+    </div>
+  )
+}

--- a/src/lib/topicoStatus.ts
+++ b/src/lib/topicoStatus.ts
@@ -1,0 +1,84 @@
+export interface RevisionItem {
+  dias: number
+  concluido?: boolean
+}
+
+export interface AtividadeExtended {
+  id: string
+  tipo: 'aula' | 'questoes' | 'revisao'
+  nome?: string
+  status?: 'pendente' | 'concluido'
+  tempo?: number
+  total?: number
+  acertos?: number
+  erros?: number
+  dataInicial?: string
+  revisoes?: RevisionItem[]
+}
+
+export interface TopicoMetrics {
+  statusGeral: 'Não Iniciado' | 'Em Progresso' | 'Concluído'
+  desempenhoMedio: number
+  proximaRevisao: string | null
+  progressoTeorico: { concluidas: number; total: number }
+}
+
+export function calculateTopicoStatus(
+  atividades: AtividadeExtended[],
+): TopicoMetrics {
+  if (!atividades.length) {
+    return {
+      statusGeral: 'Não Iniciado',
+      desempenhoMedio: 0,
+      proximaRevisao: null,
+      progressoTeorico: { concluidas: 0, total: 0 },
+    }
+  }
+  const aulas = atividades.filter(a => a.tipo === 'aula')
+  const questoes = atividades.filter(a => a.tipo === 'questoes')
+  const revisoes = atividades.filter(a => a.tipo === 'revisao')
+
+  const concluidas = aulas.filter(a => a.status === 'concluido').length
+  const progressoTeorico = {
+    concluidas,
+    total: aulas.length,
+  }
+
+  let desempenhoMedio = 0
+  if (questoes.length) {
+    const soma = questoes.reduce((acc, q) => {
+      const total = q.total ?? 0
+      const acertos = q.acertos ?? 0
+      return acc + (total ? acertos / total : 0)
+    }, 0)
+    desempenhoMedio = Number(((soma / questoes.length) * 100).toFixed(2))
+  }
+
+  let proximaRevisao: string | null = null
+  if (revisoes.length) {
+    const datas = revisoes.flatMap(rev => {
+      const base = rev.dataInicial ? new Date(rev.dataInicial) : new Date()
+      return (rev.revisoes ?? []).map(r => {
+        const d = new Date(base)
+        d.setDate(d.getDate() + r.dias)
+        return r.concluido ? null : d
+      })
+    }).filter(Boolean) as Date[]
+    if (datas.length) {
+      const min = datas.reduce((a, b) => (a < b ? a : b))
+      proximaRevisao = min.toISOString()
+    }
+  }
+
+  const concluidasTodas =
+    aulas.length > 0 && concluidas === aulas.length &&
+    desempenhoMedio >= 80 &&
+    revisoes.some(rev => (rev.revisoes ?? []).every(r => r.concluido))
+
+  return {
+    statusGeral: concluidasTodas ? 'Concluído' : 'Em Progresso',
+    desempenhoMedio,
+    proximaRevisao,
+    progressoTeorico,
+  }
+}

--- a/src/pages/TopicoDetails.tsx
+++ b/src/pages/TopicoDetails.tsx
@@ -1,25 +1,31 @@
-import { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
-import { fetchTopicoById, Topico } from '@/services/topicosService';
-import { useOrganizacao } from '@/contexts/OrganizacaoContext';
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { fetchTopicoById, Topico } from '@/services/topicosService'
+import { useOrganizacao } from '@/contexts/OrganizacaoContext'
 import ResponsiveCard from '@/components/ui/ResponsiveCard';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Book, MoreHorizontal, PlusCircle, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/DropdownMenu';
 import { FormAtividades } from '@/components/forms/AtividadeForm';
+import { TopicoStatusPanel } from '@/components/features/TopicoStatusPanel'
+import { AtividadeExtended } from '@/lib/topicoStatus'
+import { fetchAtividades } from '@/services/atividadesService'
 
 export default function TopicoDetails() {
   const { idMateria, idTopico } = useParams();
   const [topico, setTopico] = useState<Topico | null>(null);
   const { activeOrganizacao } = useOrganizacao();
   const [showAtividadeModal, setShowAtividadeModal] = useState(false);
+  const [atividades, setAtividades] = useState<AtividadeExtended[]>([])
 
   useEffect(() => {
     const load = async () => {
       if (!idTopico || !idMateria || !activeOrganizacao) return;
       const top = await fetchTopicoById(activeOrganizacao.id, idMateria, idTopico);
       setTopico(top);
+      const acts = await fetchAtividades(activeOrganizacao.id, idMateria, idTopico)
+      setAtividades(acts as unknown as AtividadeExtended[])
     };
     load();
   }, [idTopico, idMateria, activeOrganizacao]);
@@ -32,6 +38,9 @@ export default function TopicoDetails() {
     <section
       className=" grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6
         auto-rows-[minmax(50px,auto)] gap-4 grid-flow-dense" >
+      <div className="col-span-4">
+        <TopicoStatusPanel atividades={atividades} topicoNome={topico.nome} />
+      </div>
       <ResponsiveCard
         size="4x1"
         rows={1}


### PR DESCRIPTION
## Summary
- compute topic progress metrics from activities
- display metrics in a new `TopicoStatusPanel`
- show the panel on the Topic details page
