### PR TITLE
Implementa serviços de formulários de atividade

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -42,6 +42,8 @@ import { FormAtividades } from '@/components/forms/AtividadeForm'
 import { NovaMateria } from '@/types/materias'
 import { FormularioMaterias } from '@/components/forms/MateriaForm'
 import { getAuth } from 'firebase/auth'
+import { FormAtividadeSchema } from '@/schema/FormAtividadeSchema'
+import { z } from 'zod'
 
 export default function Settings() {
   const [orgs, setOrgs] = useState<Organizacao[]>([])
@@ -223,11 +225,11 @@ export default function Settings() {
     carregarTopicos()
   }
 
-  const addAtividade = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const addAtividade = async (data: z.infer<typeof FormAtividadeSchema>) => {
     if (!selectedTopico || !selectedMateria || !selectedOrg) return
     await adicionarAtividade(selectedOrg.id, selectedMateria.id, selectedTopico.id, {
-      nome: novaAtividade,
+      ...data,
+      dataInicial: (data as any).dataInicial ? (data as any).dataInicial.toISOString() : undefined,
     })
     setNovaAtividade('')
     carregarAtividades()

--- a/src/schema/FormAtividadeSchema.ts
+++ b/src/schema/FormAtividadeSchema.ts
@@ -3,7 +3,7 @@ import * as z from "zod";
 const AulaSchema = z.object({
   nome: z.string().nonempty("Nome é obrigatório"),
   tempo: z.number().min(1, "Tempo deve ser no mínimo 1 minuto"),
-  status: z.enum(["pendente", "concluído"], "Status inválido"),
+  status: z.enum(["pendente", "concluido"], "Status inválido"),
 });
 
 const RevisaoItemSchema = z.object({
@@ -24,7 +24,7 @@ const QuestoesSchema = z.object({
 });
 
 const FormAtividadeSchema = z.discriminatedUnion("tipo", [
-  z.object({ tipo: z.literal("aula"), nome: z.string(), tempo: z.number(), status: z.enum(["pendente", "concluído"]) }),
+  z.object({ tipo: z.literal("aula"), nome: z.string(), tempo: z.number(), status: z.enum(["pendente", "concluido"]) }),
   z.object({ tipo: z.literal("revisao") }).merge(RevisaoSchema),
   z.object({ tipo: z.literal("questoes"), total: z.number(), acertos: z.number(), erros: z.number() }),
 ]);

--- a/src/services/atividadesService.ts
+++ b/src/services/atividadesService.ts
@@ -3,11 +3,19 @@
 import { db } from '@/firebase'
 import { collection, getDocs, addDoc, deleteDoc, doc, updateDoc } from 'firebase/firestore'
 import { getAuth } from 'firebase/auth'
+import { RevisionItem } from '@/lib/topicoStatus'
 
 export interface Atividade {
   id: string
-  nome: string
-  // topicoId não é mais necessário no documento
+  tipo: 'aula' | 'revisao' | 'questoes'
+  nome?: string
+  tempo?: number
+  status?: 'pendente' | 'concluido'
+  total?: number
+  acertos?: number
+  erros?: number
+  dataInicial?: string
+  revisoes?: RevisionItem[]
 }
 
 // Helper para a referência da coleção
@@ -27,7 +35,11 @@ export const fetchAtividades = async (organizacaoId: string, materiaId: string, 
 }
 
 export const adicionarAtividade = async (organizacaoId: string, materiaId: string, topicoId: string, nova: Omit<Atividade, 'id'>) => {
-  return addDoc(getAtividadesCollectionRef(organizacaoId, materiaId, topicoId), nova);
+  const dataToSave = { ...nova } as Record<string, any>;
+  if (nova.dataInicial instanceof Date) {
+    dataToSave.dataInicial = nova.dataInicial.toISOString();
+  }
+  return addDoc(getAtividadesCollectionRef(organizacaoId, materiaId, topicoId), dataToSave);
 }
 
 export const deletarAtividade = async (organizacaoId: string, materiaId: string, topicoId: string, atividadeId: string) => {


### PR DESCRIPTION
## Resumo
- expande `Atividade` para contemplar dados dos formulários
- ajusta validação em `FormAtividadeSchema`
- adapta página de configurações para enviar dados completos das atividades

## Testes
- `npx vite build` *(falhou: acesso à internet bloqueado)*

------
https://chatgpt.com/codex/tasks/task_e_68754f979b608330a3c4cbdaeddcb814